### PR TITLE
Added @types/styled-jsx

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,6 +37,7 @@
     "@types/react": "^16.9.5",
     "@types/react-test-renderer": "^16.9.0",
     "@types/styled-components": "^4.1.19",
+    "@types/styled-jsx": "^2.2.8",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-styled-components": "^1.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,6 +3019,13 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
+"@types/styled-jsx@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/webpack-env@^1.13.7":
   version "1.14.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.14.0.tgz#8edfc5f8e6eae20eeed3ca0d02974ed4ee5e4efc"


### PR DESCRIPTION
Fixes Issue #15 

- [ ] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?
- [ ] Documentation?
- [x] New dependencies?

### Other Notes
We need this incase we want to sugar coat `storybook` with styled-jsx. Even then, it won't throw error. It just has vscode issues.