### PR TITLE
Added graphQL abstraction

### DIFF
--- a/packages/client/components/apollo/Query/index.tsx
+++ b/packages/client/components/apollo/Query/index.tsx
@@ -1,0 +1,42 @@
+import {
+  Query as GraphQLQuery,
+  QueryComponentOptions
+} from '@apollo/react-components'
+import { OperationVariables, QueryResult } from '@apollo/react-common'
+import { ApolloError } from 'apollo-boost'
+
+export interface QueryProps<D = any, V = OperationVariables>
+  extends Omit<QueryComponentOptions<D, V>, 'children'> {
+  loading?: JSX.Element
+  children: (data: D) => JSX.Element
+  error?: (err: ApolloError) => JSX.Element
+}
+
+function Query<D = any, V = OperationVariables>({
+  loading: loadingElement,
+  children: childrenElement,
+  error: errorElement,
+  ...props
+}: QueryProps<D, V>) {
+  const children: (result: QueryResult<D, V>) => JSX.Element = ({
+    data,
+    loading,
+    error
+  }) => {
+    if (loading) {
+      return loadingElement || <div>Loading...</div>
+    } else if (error) {
+      return errorElement ? errorElement(error) : <div>Error</div>
+    } else if (data) {
+      return childrenElement(data)
+    }
+    return <div>Error</div>
+  }
+  const grapqlProps: QueryComponentOptions<D, V> = {
+    children,
+    ...props
+  }
+  return GraphQLQuery(grapqlProps)
+}
+
+export default Query

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -1,21 +1,13 @@
 import { FunctionComponent } from 'react'
-import { Query } from '@apollo/react-components'
+import Query from '../components/apollo/Query'
 import { TestQuery } from '@code-reviewer/client/graphql/types'
 import { testQuery } from '@code-reviewer/client/graphql/queries/testQuery'
 
 const HomePage: FunctionComponent = () => {
   return (
     <Query<TestQuery> query={testQuery}>
-      {({ loading, error, data }) => {
-        if (loading) {
-          return <div>Loading...</div>
-        } else if (error) {
-          return <div>Error loading data.</div>
-        } else if (data) {
-          return <div>{data.testQuery}</div>
-        } else {
-          return <div>error</div>
-        }
+      {data => {
+        return <div>{data.testQuery}</div>
       }}
     </Query>
   )


### PR DESCRIPTION
Fixes Issue #

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?
- [ ] Documentation?
- [ ] New dependencies?

### Other Notes
We should abstract the Query component from `@apollo/react-components` because it will allow us to make modifications to it later on(We can't modify the library directly).
We will need one for Mutation component as well.