### PR TITLE
Fixed deprecated next environment

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,17 +1,15 @@
 import ExpressApolloApp from './server'
 import config from './config'
 
-/**
- * This should run only in development mode.
- */
-const { PORT, GRAPHQL_ENDPOINT } = config.API
+const { DOMAIN, PORT, GRAPHQL_ENDPOINT } = config.API
+const SERVER_DOMAIN = config.ENV === 'production' ? DOMAIN : `${DOMAIN}:${PORT}`
 
 async function main() {
   const app = await ExpressApolloApp({
     graphqlEndpoint: GRAPHQL_ENDPOINT
   })
   app.listen({ port: PORT }, () => {
-    console.log(`Server ready at http://localhost:${PORT}`)
+    console.log(`Server ready at ${SERVER_DOMAIN}`)
   })
 }
 

--- a/packages/client/config.ts
+++ b/packages/client/config.ts
@@ -1,13 +1,15 @@
-import getConfig from 'next/config'
+export type Environment = 'development' | 'production'
+
 export interface NextConfig {
   SERVER_DOMAIN: string
   GRAPHQL_ENDPOINT: string
-  ENV: 'development' | 'production'
+  ENV: Environment
 }
 
-const nextConfigs = getConfig()
 const config: Readonly<NextConfig> = Object.freeze({
-  ...nextConfigs.publicRuntimeConfig
+  SERVER_DOMAIN: process.env.SERVER_DOMAIN as string,
+  GRAPHQL_ENDPOINT: process.env.GRAPHQL_ENDPOINT as string,
+  ENV: process.env.ENV as Environment
 })
 
 export default config

--- a/packages/client/next.config.js
+++ b/packages/client/next.config.js
@@ -4,7 +4,7 @@ const SERVER_DOMAIN =
   env.ENV === 'production' ? env.DOMAIN : `${env.DOMAIN}:${env.PORT}`
 
 module.exports = {
-  publicRuntimeConfig: {
+  env: {
     SERVER_DOMAIN,
     GRAPHQL_ENDPOINT: env.GRAPHQL_ENDPOINT,
     ENV: env.ENV


### PR DESCRIPTION
Fixes Issue #

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?
- [ ] Documentation?
- [ ] New dependencies?

### Other Notes
https://github.com/zeit/next.js/blob/master/errors/serverless-publicRuntimeConfig.md
`publicRuntimeConfig` is deprecated in favor of `env`. It will also throw an error if you try running serverlessly.